### PR TITLE
Fix boost in date/date queries

### DIFF
--- a/src/whoosh/fields.py
+++ b/src/whoosh/fields.py
@@ -885,7 +885,7 @@ class DATETIME(NUMERIC):
         if is_ambiguous(at):
             startnum = datetime_to_long(at.floor())
             endnum = datetime_to_long(at.ceil())
-            return query.NumericRange(fieldname, startnum, endnum)
+            return query.NumericRange(fieldname, startnum, endnum, boost=boost)
         else:
             return query.Term(fieldname, at, boost=boost)
 

--- a/src/whoosh/qparser/syntax.py
+++ b/src/whoosh/qparser/syntax.py
@@ -450,6 +450,7 @@ class RangeNode(SyntaxNode):
     """
 
     has_fieldname = True
+    has_boost = True
 
     def __init__(self, start, end, startexcl, endexcl):
         self.start = start


### PR DESCRIPTION
Fixed boost missing in ambiguous date queries
Fices incorrect value in RangeNode.has_boost